### PR TITLE
Fix static page title being duplicated

### DIFF
--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -16,7 +16,6 @@
 			<div class="col-xs-12">
 				<div class="post-box">
 					<div class="post-box__intro">
-						<h1 class="post-box__title"><?php echo esc_html( get_the_title() ); ?></h1>
 						<?php the_title( '<h1 class="post-box__title">', '</h1>' ); ?>
 					</div>
 					<?php if ( get_the_content() !== '' ) : ?>


### PR DESCRIPTION
The two lines of code generated the exact same HTML, so I kept the "wordpress-standard" one